### PR TITLE
build(ci): added Procfile for migrate/fixture in application startup.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,12 +24,9 @@ jobs:
       - name: Install pack
         uses: buildpacks/github-actions/setup-pack@v5.8.7
 
-      # need GOOGLE_RUNTIME explicity
-      # https://github.com/GoogleCloudPlatform/buildpacks/issues/220#issuecomment-1199867259
       - name: Publish packages
         run: |
           pack build ghcr.io/hwakabh/6ow3idgirl:latest \
-            --builder gcr.io/buildpacks/builder:latest \
+            --builder heroku/builder:24 \
             --path . \
-            --env GOOGLE_RUNTIME=nodejs \
             --publish

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+web: npm run start
+migrate: npm run typeorm migration:run
+fixture: npm run fixtures


### PR DESCRIPTION
# Issue link
N/A

# What does this PR do?
- added Procfile for multiple commands inside built images
- updated builders from google-cloud to heroku

# (Optional) Additional Contexts for PR Reviews
added Procfile for running migrations and loading fixtures after built images.