### PR TITLE
fix(deploy): enabled to fetch application port via PORT envars.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,6 @@ async function bootstrap() {
   //   res.render("error");
   // });
 
-  await app.listen(8080);
+  await app.listen(process.env.PORT || 8080);
 }
 bootstrap();


### PR DESCRIPTION
# Issue link
relates: #115 

# What does this PR do?
- enabled to fetch PORT envars if defined in platform side

# (Optional) Additional Contexts for PR Reviews
Since Dynos on Heroku has awaiting PORT from envar below, and this might be different from 8080, which `main.ts` is expecting.

```shell
~ $ env 
MYSQL_PORT=3306
COREPACK_ENABLE_DOWNLOAD_PROMPT=0
MEMORY_AVAILABLE=512
PWD=/app
PORT=34975
NODE_ENV=production
_=/usr/bin/env
NPM_CONFIG_PRODUCTION=false
NODE_HOME=/app/.heroku/node
COREPACK_HOME=/app/.heroku/corepack
HOME=/app
TERM=xterm-256color
SHLVL=1
WEB_MEMORY=512
WEB_CONCURRENCY=1
PS1=\[\033[01;34m\]\w\[\033[00m\] \[\033[01;32m\]$ \[\033[00m\]
PATH=/app/.heroku/node/bin:/app/.heroku/yarn/bin:/usr/local/bin:/usr/bin:/bin:/app/bin:/app/node_modules/.bin
DYNO=run.7134
# ...
```