### PR TITLE
fix(deploy): updated postdeploy commands and required envars.

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,10 +1,13 @@
 {
   "name": "roza-6ow3idgirl.com",
   "scripts": {
-    "postdeploy": "/cnb/process/migrate && /cnb/process/fixture",
-    "pr-predestroy": "/cnb/process/migrate && /cnb/process/fixture"
+    "postdeploy": "npm run typeorm migration:run && npm run fixtures",
+    "pr-predestroy": "npm run typeorm migration:run && npm run fixtures"
   },
   "env": {
+    "URL": {
+      "required": false
+    },
     "JAWSDB_URL": {
       "required": true
     },

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -20,6 +20,7 @@ export class AppController {
   @Get('/')
   @Render('home')
   async root() : Promise<AppRootResponse> {
+    // platform specific for Nest MVC to fetch URL of application backend
     const url: string = this.configService.get('URL') ?? 'http://localhost:8080';
 
     const musics: object = await firstValueFrom(this.httpService.get(url + '/music'));


### PR DESCRIPTION
# Issue link
relates: #115 

# What does this PR do?
- updated post-deploy commands with npm-script
- updated app.json for adding requirements of `URL` envars
- added URL to Dyno configurations (this can be fetched via `HEROKU_APP_DEFAULT_DOMAIN_NAME ` but not working as described below)

```shell
% heroku config:get URL --app roza-6ow3idgirl 
https://roza-6ow3idgirl-fb86f6a7e0ab.herokuapp.com
```

# (Optional) Additional Contexts for PR Reviews
Regarding `URL` variables, we need to provide the value depending on the platform when we use MVC feature of Nest.
Seems that we can fetch Heroku-generated URL via [Dyno metadata](https://devcenter.heroku.com/articles/dyno-metadata) as experimental features, but only `HEROKU_DYNO_ID` is available as its functionalities, so we need to add `URL` as Heroku configurations.

```shell
% heroku labs:enable runtime-dyno-metadata -a roza-6ow3idgirl
Enabling runtime-dyno-metadata for roza-6ow3idgirl... done

% heroku labs:enable runtime-dyno-build-metadata  -a roza-6ow3idgirl
Enabling runtime-dyno-build-metadata for roza-6ow3idgirl... done

% heroku labs --app roza-6ow3idgirl
=== User Features hrykwkbys1024@gmail.com

[ ] app-overview                         An overview page for an app
[+] d2e-auto-provisioning                Enables Direct to Enterprise auto-provisioning [limited]
[ ] dashboard-mlab-shutdown-banner       Enable display of mlab shutdown banner
[+] dashboard-pb-websockets              allow user to connect to particleboard for eventbus events via websocket [alpha]
[+] frontend-enterprise-overages         View Enterprise license overages in Dashboard Account/Usage [alpha]
[+] frontend-larger-dynos                Internal flag to show larger ram dynos [alpha]
[ ] metrics-beta                         App Metrics Beta Features
[ ] metrics-chart-config                 Set order and visibility preferences for your metrics charts
[ ] metrics-data-lag                     Adds an indicator to your graphs when data is still processing, or not available. Prevents graphs from falling off before data is available, or when a data gap occurs.
[ ] metrics-p99-max-response-times       Modifies the Response Time plot to include P99 and Max latency time series.
[ ] metrics-platform-status-events       Display Heroku platform incidents and scheduled maintenance for your application’s region in the Application Metrics Events chart.
[ ] metrics-request-volume               Modifies the Throughput plot to change units from request per minute to requests per second and also display request volume stratified by status code.
[ ] metrics-response-time-summary        Shows summary average statistics for response time over a given time period.
[ ] metrics-seven-day-lookback           Allows you to see data from the past seven days of data on the same chart
[ ] metrics-three-day-lookback           Allows you to see data from the the past two 24-hour periods
[ ] metrics-three-day-lookback-combined  Allows viewing the past three days of data on the same chart
[+] mfa-required                         Allows rollout of mfa requirement to all users [limited]
[+] prefixed-access-token                Enables prefixes on access tokens [limited]
[ ] team-internal-routing                Enables access to Internal Routing in Private Spaces for a team

=== App Features ⬢ roza-6ow3idgirl

[ ] app-alerting                    Allows the creation of alerts for Web Dynos
[ ] build-in-app-dir                Make the build system use /app as the build directory
[ ] generation-specific-pipelines   Determines if GET /pipelines/:id_or_name should return generation detail, and if POST /pipeline-couplings should perform generation-specific validation.
[ ] go-language-metrics             Display language specific metrics for Go apps
[ ] http-disable-http2              Disable HTTP/2 in Router 2.0.
[ ] http-disable-keepalive-to-dyno  Disable Keepalives to Dynos in Router 2.0.
[ ] http-end-to-end-continue        Send 100-continue headers to the backend
[ ] log-runtime-metrics             Emit dyno resource usage information into app logs
[ ] nodejs-language-metrics         Display language specific metrics for Node.js apps
[ ] ruby-language-metrics           Display language specific metrics for Ruby apps
[+] runtime-dyno-build-metadata     Share dyno build metadata on filesystem at /etc/heroku/dyno
[+] runtime-dyno-metadata           Share dyno metadata in environment variables
[ ] runtime-empty-entrypoint        Force an empty entrypoint when one is not present in the container image
[ ] runtime-heroku-exec             Enable Heroku Exec for all dynos on an app
[ ] runtime-heroku-metrics          Displays language-specific memory metrics.
[ ] runtime-new-layer-extract       Use new layer extraction tool for container image
[ ] runtime-tar-layer-extract       Use tar as the layer extraction tool for container image
[ ] spaces-extra-resolver           causes the container runtime to lookup and inject a single IP from the HEROKU_EXTRA_RESOLVER config var as an extra DNS resolver
[ ] spaces-no-sni                   Allow space router to terminate non-SNI TLS connections
[ ] web-auto-scaling                Allows autoscaling based on a desired latency (p95)
```